### PR TITLE
feat: refactor auth pages

### DIFF
--- a/client/src/lib/components/TextField.svelte
+++ b/client/src/lib/components/TextField.svelte
@@ -1,21 +1,18 @@
 <script lang="ts">
-  import classNames from 'classnames';
+  import Warning from "~icons/custom/warning";
 
-  export let type: 'text' | 'number' | 'email' | 'password' | 'date' = 'text';
+  export let type: "text" | "number" | "email" | "password" | "date" = "text";
   export let name: string;
-  export let id = '';
+  export let id = "";
   export let error: string | null = null;
   export let value: string | number | Date | null = null;
   export let label: string | null = null;
   export let placeholder: string | undefined = undefined;
   export let required = false;
-  export let autocomplete: 'true' | 'false' | undefined = undefined;
-  let customClassNames = '';
-  export { customClassNames as class };
-  let className = classNames(
-    customClassNames,
-    'text-md  font-semibold bg-gray-50 px-3 py-3 placeholder-slate-300 text-slate-600 rounded-lg text-sm outline-none focus:outline-none focus:ring w-full'
-  );
+  export let autocomplete: "true" | "false" | undefined = undefined;
+  let className = "";
+  export { className as class };
+
   const handleInput = (event: Event): void => {
     const target = event.target as HTMLInputElement;
     value = type.match(/^(number|range)$/) ? +target.value : target.value;
@@ -25,23 +22,72 @@
 {#if label}
   <label
     for={name}
-    class:text-red-600={!!error}
-    class="block text-sm font-medium text-gray-700 pb-2">{label}</label
+    class:underline={!!error}
+    class:text-rose-600={!!error}
+    class="block text-sm font-medium text-gray-700">{label}</label
   >
 {/if}
 
-<input
-  {name}
-  {id}
-  {placeholder}
-  {required}
-  {autocomplete}
-  {type}
-  {value}
-  class:border-red-600={!!error}
-  class={className}
-  on:change
-  on:blur
-  on:input={handleInput}
-/>
-<p class:opacity-0={!error} class="text-sm pt-1 text-red-600">{error}</p>
+<div class="input_wrapper">
+  <div class="input_container">
+    <input
+      {required}
+      {autocomplete}
+      id={id || name}
+      {type}
+      {name}
+      {value}
+      {placeholder}
+      class="input{className ? ' ' + className : ''}"
+      class:input_error={!!error}
+      on:input={handleInput}
+    />
+    {#if error}
+    <figure class="icon_error_icon_container">
+      <Warning class="input_error_icon" />
+    </figure>
+    {/if}
+  </div>
+  {#if error}
+    <p class="input_error_message">{error}</p>
+  {/if}
+</div>
+
+<style lang="postcss">
+  .input_wrapper {
+    @apply flex flex-col;
+  }
+
+  .input_container {
+    @apply flex relative;
+  }
+
+  .input_error_icon {
+    @apply text-rose-600 h-4 w-4;
+  }
+
+  .icon_error_icon_container {
+    @apply flex items-center justify-center p-4 pointer-events-none;
+    @apply absolute right-0 top-0;
+  }
+
+  .input_error_message {
+    @apply text-rose-600 text-sm;
+  }
+
+  .input {
+    @apply bg-gray-200 border border-transparent rounded text-gray-800;
+    @apply w-full p-3 text-[.9rem];
+  }
+
+  .input:active,
+  .input:focus {
+    @apply outline-none border-gray-400;
+  }
+
+  .input_error,
+  .input_error:active,
+  .input_error:focus {
+    @apply border-rose-600 text-rose-600;
+  }
+</style>

--- a/client/src/routes/(auth)/+layout.svelte
+++ b/client/src/routes/(auth)/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import Card from '$lib/components/Card.svelte';
   import type { Unsplash } from '../api/unsplash/+server';
 
   let cover: Unsplash;
@@ -17,17 +16,24 @@
   });
 </script>
 
-<div
-  class="flex bg-gray-900 min-h-screen justify-center items-center bg-cover bg-no-repeat"
-  style="background-image: var(--cover-image);"
->
-  <Card class="h-max w-full mx-2 md:w-1/2 xl:w-1/4">
-    <slot />
-  </Card>
-  <small class="text-sm text-white fixed bottom-4 right-4"
-    >Photo by <a
+<main class="auth_view" style="background-image: url({cover?.url});">
+  <article class="sidebar">
+    <div class="container">
+      <slot />
+    </div>
+    <footer class="footer">
+      <small>
+        Gabble is an MIT Licensed solution
+        <br />
+        Contribute to the project on{" "}
+        <a href="https://github.com/whizzes/gabble" class="text-blue-600 underline" target="_blank"> GitHub </a>
+      </small>
+    </footer>
+  </article>
+  <small class="text-sm text-white fixed bottom-4 right-4">
+    Photo by <a
       class="underline font-semibold"
-      href={`https://unsplash.com/@${cover?.author?.username}?utm_source=gabble&utm_medium=referral`}
+      href="https://unsplash.com/@{cover?.author?.username}"
       >{cover?.author?.name || ''}</a
     >
     on
@@ -38,4 +44,29 @@
       Unsplash</a
     ></small
   >
-</div>
+</main>
+
+
+<style lang="postcss">
+  .auth_view {
+    @apply bg-cover bg-center bg-no-repeat flex h-screen overflow-hidden;
+  }
+
+  .sidebar {
+    @apply bg-white flex flex-col justify-between items-center w-full shadow-md;
+  }
+
+  @media screen(md) {
+    .sidebar {
+      @apply w-[390px];
+    }
+  }
+
+  .container {
+    @apply h-full w-11/12;
+  }
+
+  .footer {
+    @apply flex flex-col text-gray-600 p-4 text-center;
+  }
+</style>

--- a/client/src/routes/(auth)/login/+page.svelte
+++ b/client/src/routes/(auth)/login/+page.svelte
@@ -1,46 +1,59 @@
 <script lang="ts">
-  import { newForm } from '@whizzes/svelte-forms';
-  import * as Yup from 'yup';
-  import { notifications } from '@whizzes/svelte-notifications';
+  import { newForm } from "@whizzes/svelte-forms";
+  import { notifications } from "@whizzes/svelte-notifications";
+  import { onMount } from "svelte";
+  import * as Yup from "yup";
 
-  import { createHeader } from '$lib/utils/basic-auth';
-  import { LoginError, type ErrorMessages } from './shared';
-  import { UserErrorCode } from '$lib/graphql/schema';
-  import TextField from '$lib/components/TextField.svelte';
-  import Button from '$lib/components/Button.svelte';
+  import { createHeader } from "$lib/utils/basic-auth";
+  import { LoginError, type ErrorMessages } from "./shared";
+  import { UserErrorCode } from "$lib/graphql/schema";
+  import TextField from "$lib/components/TextField.svelte";
+  import Button from "$lib/components/Button.svelte";
+
+  import type { Unsplash } from "../../api/unsplash/+server";
+
+  let cover: Unsplash | null = null;
+  let error: string | null = null;
+
+  onMount(async () => {
+    const response = await fetch("/api/unsplash");
+    const data = await response.json();
+
+    cover = data.data;
+  });
 
   const errorMessages: ErrorMessages = {
-    [LoginError.MissingCredentials]: 'Please enter your email and password',
-    [UserErrorCode.Unauthorized]: 'Invalid email or password',
+    [LoginError.MissingCredentials]: "Please enter your email and password",
+    [UserErrorCode.Unauthorized]: "Invalid email or password",
   };
 
   const { handleSubmit, values, errors, isSubmitting } = newForm({
     initialValues: {
-      email: '',
-      password: '',
+      email: "",
+      password: "",
     },
     validationSchema: Yup.object({
-      email: Yup.string().email().required('Email is required'),
-      password: Yup.string().required('Password is required'),
+      email: Yup.string().email().required("Email is required"),
+      password: Yup.string().required("Password is required"),
     }),
     onSubmit: async ({ email, password }) => {
       const basicAuth = createHeader(email, password);
-      const response = await fetch('/login', {
-        method: 'POST',
+      const response = await fetch("/login", {
+        method: "POST",
         headers: {
           Authorization: basicAuth,
         },
       });
 
       if (response.ok) {
-        notifications.notifySuccess('Logged in successfully');
-        window.location.pathname = '/';
+        notifications.notifySuccess("Logged in successfully");
+        window.location.pathname = "/";
       } else {
         const data = await response.json();
 
         const errorMessage =
           errorMessages[data.error as keyof typeof errorMessages] ||
-          'An error occurred. Please try again later.';
+          "An error occurred. Please try again later.";
 
         notifications.notifyFailure(errorMessage);
       }
@@ -48,37 +61,40 @@
   });
 </script>
 
-<h3 class="text-2xl">Login into your account</h3>
-<form
-  on:submit|preventDefault={handleSubmit}
-  class="flex flex-col w-full mt-8 space-y-1"
->
-  <TextField
-    name="email"
-    type="email"
-    label="Email"
-    placeholder="john@example.com"
-    bind:value={$values.email}
-    error={$errors.email}
-  />
-  <TextField
-    type="password"
-    name="password"
-    label="Password"
-    placeholder="• • • • • • • •"
-    bind:value={$values.password}
-    error={$errors.password}
-  />
-
-  <div class="flex justify-between">
-    <Button type="submit" disabled={$isSubmitting} variant="primary"
-      >Login</Button
-    >
-    <Button
-      disabled={$isSubmitting}
-      on:click={() => {
-        window.location.href = '/signup';
-      }}>Create an account</Button
-    >
+<div class="flex flex-col justify-center h-full">
+  <div class="py-4">
+    <h1 class="font-semibold">Welcome Back!</h1>
+    <span>
+      Log in to your account to continue
+    </span>
   </div>
-</form>
+  <form class="flex flex-col py-4 space-y-4" on:submit={handleSubmit}>
+    <TextField
+      type="text"
+      name="userId"
+      error={$errors.email}
+      bind:value={$values.email}
+      placeholder="Email"
+    />
+    <TextField
+      type="password"
+      name="password"
+      error={$errors.password}
+      bind:value={$values.password}
+      placeholder="Password"
+    />
+    <div>
+      <label for="remeber_credentials">
+        <input type="checkbox" name="remeber_credentials" />
+        <small>Keep me logged in</small>
+      </label>
+    </div>
+    <p class="error_message" hidden={!error}>{error}</p>
+    <Button type="submit" variant="primary">
+      Log in
+    </Button>
+  </form>
+  <small class="text-gray-600">
+    Don't have an account? <a class="text-blue-600 underline" href="/signup">Sign up</a>
+  </small>
+</div>

--- a/client/src/routes/(auth)/login/+server.ts
+++ b/client/src/routes/(auth)/login/+server.ts
@@ -11,7 +11,7 @@ import { LoginError } from './shared';
 export async function createToken(
   urqlClient: Client,
   email: string,
-  password: string
+  password: string,
 ): Promise<AccessToken> {
   const response = await urqlClient
     .mutation(
@@ -22,7 +22,7 @@ export async function createToken(
       },
       {
         requestPolicy: 'network-only',
-      }
+      },
     )
     .toPromise();
 
@@ -57,7 +57,7 @@ export const POST = async ({
         }),
         {
           status: 422,
-        }
+        },
       );
     }
 
@@ -91,7 +91,7 @@ export const POST = async ({
       }),
       {
         status: 500,
-      }
+      },
     );
   }
 };

--- a/client/src/routes/(auth)/signup/+page.svelte
+++ b/client/src/routes/(auth)/signup/+page.svelte
@@ -36,27 +36,31 @@
   });
 </script>
 
-<h2 class="text-2xl font-bold text-gray-900 dark:text-white">
-  Create an account
-</h2>
-<form class="flex flex-col w-full mt-8 space-y-1" on:submit={handleSubmit}>
-  <TextField
+<div class="flex flex-col justify-center h-full">
+  <div class="py-4">
+    <h1 class="font-semibold">Welcome to Gabble!</h1>
+    <span>
+     Create an account to continue
+    </span>
+  </div>
+  <form class="flex flex-col py-4 space-y-4" on:submit={handleSubmit}>
+    <TextField
     id="name"
     name="name"
     type="text"
     placeholder="E.g. John"
     label="Name"
-    bind:value={$values.name}
     error={$errors.name}
+    bind:value={$values.name}
   />
   <TextField
     id="surname"
     name="surname"
     type="text"
     placeholder="E.g. Appleseed"
-    label="Last name"
-    bind:value={$values.surname}
+    label="Surname"
     error={$errors.surname}
+    bind:value={$values.surname}
   />
   <TextField
     id="username"
@@ -64,8 +68,8 @@
     type="text"
     placeholder="E.g. johndoe"
     label="Username"
-    bind:value={$values.username}
     error={$errors.username}
+    bind:value={$values.username}
   />
   <TextField
     id="email"
@@ -73,25 +77,23 @@
     type="email"
     placeholder="E.g. user@email.com"
     label="Email"
-    bind:value={$values.email}
     error={$errors.email}
+    bind:value={$values.email}
   />
   <TextField
     type="password"
     id="password"
     name="password"
     label="Password"
-    placeholder="• • • • • • • •"
-    bind:value={$values.password}
+    placeholder="•••••••"
     error={$errors.password}
+    bind:value={$values.password}
   />
-  <div class="flex justify-between">
-    <Button variant="primary" type="submit" disabled={$isSubmitting}
-      >Create account</Button
-    >
-    <Button
-      on:click={() => (window.location.href = '/login')}
-      disabled={$isSubmitting}>Login into your account</Button
-    >
-  </div>
-</form>
+    <Button type="submit" variant="primary">
+      Sign up
+    </Button>
+  </form>
+  <small class="text-gray-600">
+    Already have an account? <a class="text-blue-600 underline" href="/login">Log in</a>
+  </small>
+</div>

--- a/client/src/routes/(auth)/signup/+server.ts
+++ b/client/src/routes/(auth)/signup/+server.ts
@@ -15,7 +15,7 @@ export type CreateUserPayload = {
 
 async function createUser(
   urqlClient: Client,
-  payload: CreateUserPayload
+  payload: CreateUserPayload,
 ): Promise<{ id: string }> {
   const response = await urqlClient
     .mutation(
@@ -23,7 +23,7 @@ async function createUser(
       { input: payload },
       {
         requestPolicy: 'network-only',
-      }
+      },
     )
     .toPromise();
 
@@ -58,7 +58,7 @@ export const POST = async ({
     const tokens = await createToken(
       urqlClient,
       requestBody.email,
-      requestBody.password
+      requestBody.password,
     );
 
     if (tokens.accessToken) {
@@ -82,7 +82,7 @@ export const POST = async ({
       }),
       {
         status: 403,
-      }
+      },
     );
   } catch (err) {
     console.error(err);
@@ -94,7 +94,7 @@ export const POST = async ({
       }),
       {
         status: 500,
-      }
+      },
     );
   }
 };

--- a/client/src/routes/api/unsplash/+server.ts
+++ b/client/src/routes/api/unsplash/+server.ts
@@ -17,7 +17,7 @@ export type Unsplash = {
 
 export async function GET(event: RequestEvent) {
   const UNSPLASH_DAILY_BACKGROUND = event.cookies.get(
-    'UNSPLASH_DAILY_BACKGROUND'
+    'UNSPLASH_DAILY_BACKGROUND',
   );
 
   if (UNSPLASH_DAILY_BACKGROUND) {
@@ -27,7 +27,7 @@ export async function GET(event: RequestEvent) {
         data: JSON.parse(UNSPLASH_DAILY_BACKGROUND),
         error: null,
         success: true,
-      })
+      }),
     );
   }
 
@@ -73,7 +73,7 @@ export async function GET(event: RequestEvent) {
           data: response,
           success: true,
           error: null,
-        })
+        }),
       );
     }
   }
@@ -86,6 +86,6 @@ export async function GET(event: RequestEvent) {
       },
       data: null,
       success: false,
-    })
+    }),
   );
 }


### PR DESCRIPTION
Refactors auth pages (`/login` and `/signup`) to have them following the same
layout and input designs.

Other improvements include responsiveness and removal of `classNames` to use
Svelte's `class:foo={boolean|condititon}` syntax instead.

## Demo


https://github.com/whizzes/gabble/assets/34756077/c5b2f206-8a3d-447a-b318-7b9739533c95

