### PR TITLE
feat: query posts from user edge

### DIFF
--- a/crates/server/src/graphql/modules/post/query/mod.rs
+++ b/crates/server/src/graphql/modules/post/query/mod.rs
@@ -3,7 +3,7 @@ mod posts;
 use async_graphql::{Context, Object, Result};
 use pxid::graphql::Pxid;
 
-use self::posts::{PostFilterInput, Posts, PostsConnection};
+use self::posts::{Posts, PostsConnection};
 
 #[derive(Debug, Default)]
 pub struct PostQueryRoot;
@@ -17,8 +17,7 @@ impl PostQueryRoot {
         before: Option<Pxid>,
         first: Option<i32>,
         last: Option<i32>,
-        filter: Option<PostFilterInput>,
     ) -> Result<PostsConnection> {
-        Posts::exec(ctx, after, before, first, last, filter).await
+        Posts::exec(ctx, after, before, first, last).await
     }
 }

--- a/crates/server/src/graphql/modules/post/query/posts.rs
+++ b/crates/server/src/graphql/modules/post/query/posts.rs
@@ -1,6 +1,5 @@
 use async_graphql::connection::{query, Connection, Edge, EmptyFields};
-use async_graphql::{Context, InputObject, Result};
-use gabble::post::repository::PostFilter;
+use async_graphql::{Context, Result};
 use pxid::graphql::Pxid;
 
 use gabble::shared::pagination::Pagination;
@@ -11,19 +10,6 @@ use crate::graphql::modules::post::types::Post;
 
 pub type PostsConnection = Connection<Pxid, Post, ConnectionDetails, EmptyFields>;
 
-#[derive(Debug, Default, InputObject)]
-pub struct PostFilterInput {
-    pub author_id: Option<Pxid>,
-}
-
-impl From<PostFilterInput> for PostFilter {
-    fn from(value: PostFilterInput) -> Self {
-        PostFilter {
-            author_id: value.author_id.map(|id| id.into_inner()),
-        }
-    }
-}
-
 pub struct Posts;
 
 impl Posts {
@@ -33,7 +19,6 @@ impl Posts {
         before: Option<Pxid>,
         first: Option<i32>,
         last: Option<i32>,
-        filter: Option<PostFilterInput>,
     ) -> Result<PostsConnection> {
         let context = ctx.data_unchecked::<SharedContext>();
         let after = after.map(|a| a.to_string());
@@ -54,11 +39,7 @@ impl Posts {
                     first,
                     last,
                 )?;
-                let query_set = context
-                    .services
-                    .post
-                    .list(Some(pagination), Some(filter.unwrap_or_default().into()))
-                    .await?;
+                let query_set = context.services.post.list(Some(pagination), None).await?;
                 let total_count = query_set.count();
                 let posts = query_set.records();
                 let page_info = pagination.get_page_info(total_count);

--- a/crates/server/src/graphql/modules/user/types.rs
+++ b/crates/server/src/graphql/modules/user/types.rs
@@ -1,7 +1,16 @@
-use async_graphql::{Enum, SimpleObject};
+use async_graphql::connection::{query, Connection, Edge, EmptyFields};
+use async_graphql::{ComplexObject, Context, Enum, Result, SimpleObject};
 use chrono::{DateTime, Utc};
+use gabble::post::repository::PostFilter;
+use gabble::shared::pagination::Pagination;
 use pxid::graphql::Pxid;
 use serde::{Deserialize, Serialize};
+
+use crate::context::SharedContext;
+use crate::graphql::connection_details::ConnectionDetails;
+use crate::graphql::modules::post::types::Post;
+
+pub type UserPostsConnection = Connection<Pxid, Post, ConnectionDetails, EmptyFields>;
 
 #[derive(Copy, Clone, Debug, Deserialize, Enum, Eq, PartialEq, Serialize)]
 pub enum UserErrorCode {
@@ -32,6 +41,72 @@ pub struct User {
     pub email: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+#[ComplexObject]
+impl User {
+    /// Lists posts authored by this user
+    async fn posts(
+        &self,
+        ctx: &Context<'_>,
+        after: Option<Pxid>,
+        before: Option<Pxid>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> Result<UserPostsConnection> {
+        let context = ctx.data_unchecked::<SharedContext>();
+        let after = after.map(|a| a.to_string());
+        let before = before.map(|a| a.to_string());
+
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after: Option<Pxid>,
+             before: Option<Pxid>,
+             first: Option<usize>,
+             last: Option<usize>| async move {
+                let pagination = Pagination::new(
+                    after.map(|id| id.into_inner()),
+                    before.map(|id| id.into_inner()),
+                    first,
+                    last,
+                )?;
+                let query_set = context
+                    .services
+                    .post
+                    .list(
+                        Some(pagination),
+                        Some(PostFilter {
+                            author_id: Some(self.id.into_inner()),
+                        }),
+                    )
+                    .await?;
+                let total_count = query_set.count();
+                let posts = query_set.records();
+                let page_info = pagination.get_page_info(total_count);
+                let mut connection = UserPostsConnection::with_additional_fields(
+                    page_info.has_prev_pages,
+                    page_info.has_next_pages,
+                    ConnectionDetails { total_count },
+                );
+
+                connection.edges.extend(posts.into_iter().filter_map(|p| {
+                    match Post::try_from(p) {
+                        Ok(p) => Some(Edge::new(p.id, p)),
+                        Err(err) => {
+                            tracing::error!(%err, "Failed to create post instance from result");
+                            None
+                        }
+                    }
+                }));
+
+                Ok::<UserPostsConnection, async_graphql::Error>(connection)
+            },
+        )
+        .await
+    }
 }
 
 impl From<gabble::user::model::User> for User {

--- a/crates/test/src/modules/post/post_create.rs
+++ b/crates/test/src/modules/post/post_create.rs
@@ -59,18 +59,17 @@ async fn create_post() {
         .await
         .unwrap();
     let token = TestUtil::token_create(&test_util, user.id).await;
-    let result = schema
-        .execute(
-            Request::new(CREATE_POST_MUTATION)
-                .data(token)
-                .variables(Variables::from_json(json!({
+    let result =
+        schema
+            .execute(Request::new(CREATE_POST_MUTATION).data(token).variables(
+                Variables::from_json(json!({
                   "payload":{
                     "title":"Hello World!",
                     "content":"Hello, new post!"
                   }
-                }))),
-        )
-        .await;
+                })),
+            ))
+            .await;
     let data = result.data.into_json().unwrap();
     let post_data = &data["postCreate"]["post"];
 
@@ -108,35 +107,33 @@ async fn creates_post_with_parent() {
         .await
         .unwrap();
     let token = TestUtil::token_create(&test_util, user.id).await;
-    let result_parent = schema
-        .execute(
-            Request::new(CREATE_POST_MUTATION)
-                .data(token)
-                .variables(Variables::from_json(json!({
+    let result_parent =
+        schema
+            .execute(Request::new(CREATE_POST_MUTATION).data(token).variables(
+                Variables::from_json(json!({
                   "payload":{
                     "title":"Hello World!",
                     "content":"Hello, new post!",
                   }
-                }))),
-        )
-        .await;
+                })),
+            ))
+            .await;
 
     let post_parent_data = result_parent.data.into_json().unwrap();
     let post_parent_id = &post_parent_data["postCreate"]["post"]["id"];
     let token = TestUtil::token_create(&test_util, user.id).await;
-    let result = schema
-        .execute(
-            Request::new(CREATE_POST_MUTATION)
-                .data(token)
-                .variables(Variables::from_json(json!({
+    let result =
+        schema
+            .execute(Request::new(CREATE_POST_MUTATION).data(token).variables(
+                Variables::from_json(json!({
                   "payload":{
                     "title":"Hello again!",
                     "content":"Hello, new post again!",
                     "parentId":post_parent_id
                   }
-                }))),
-        )
-        .await;
+                })),
+            ))
+            .await;
 
     let data = result.data.into_json().unwrap();
     let post_data = &data["postCreate"]["post"];


### PR DESCRIPTION
Now we query posts for a user from its edge which means that instead
of querying posts by a user with ID `user_1234` like this:

```gql
query {
  posts(filter: { author_id: 'user_1234' }) {
    # -- snip --
  }
}
```

We will do:

```gql
query {
  users(filter: { id: 'user_1234' }) {
    # -- snip --
        posts(first: 20) {
          id
          title
          # -- snip --
        }
  }
}
```